### PR TITLE
update `lakefile.lean` to work on Lake version 5.0.0-v4.21.0 & add other miscellaneous changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /.lake
+
+### Created by https://www.gitignore.io
+### direnv ###
+.direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ In short, you will basically have to: (You can skip this paragraph if you want a
 2. Modify your `lakefile.lean` to...
     1. compile the `.c` file to produce a static lib,
     2. and add the necessary compilation/linking flags to link `libglfw.so` and the static lib of the `.c` to your Lean4 application executable whenever you do `$ lake build`.
+    3. **(TIP: If you are new to writing a `lakefile.lean`, see https://github.com/leanprover/lean4/blob/master/src/lake/README.md and the directory `examples/` in there)**
 3. Write `opaque` Lean4 definitions in a `.lean` module in your Lean4 project that point to the certain functions written in that `.c` file. You might also have to define some opaque structures if the FFI functions return pointers to, say, a C handle object.
+
+### // Sidenote
+
+For convenience - if you know how to use `nix`, you can do `nix develop` to pull
+in the necessary dependencies. There is a `flake.nix` in this repository with a
+devShell that installs `lean4` and `glfw3` for you. After `nix develop`, you
+should be able to directly run `./run.sh` to execute the sample FFI program.
 
 ## A brief introduction on GLFW
 
@@ -618,6 +626,10 @@ def main : IO Unit := do
 
 All the code is in this repository. Do `$ ./run.sh` to build and run the final GLFW example app.
 
-# TODOs
-- [ ] Investigate on constructing `lean_obj_res *` objects of Lean4 inductive types in C.
-- [ ] Understand what borrowing is and how it affects programming an FFI.
+# Extra readings
+
+- To learn more about FFI in Lean4, you may want to go to
+  https://github.com/leanprover/lean4/blob/master/doc/dev/ffi.md.
+- To learn about writing a `lakefile.lean` (or `lakefile.toml`), see
+  https://github.com/leanprover/lean4/blob/master/src/lake/README.md and the
+  directory `examples/` in there.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ There seems to be no complete tutorial on creating C FFI bindings in Lean4. So I
 - https://lean-lang.org/lean4/doc/dev/ffi.html (it seems to be outdated as it uses a keyword called `constant`, which does not actually exist in Lean4).
 - https://github.com/leanprover/lean4/tree/master/src/lake/examples/ffi
 
+## Lean4 Version
+
+This project has been tested on these versions of Lean4 and Lake:
+
+```
+$ lean --version
+Lean (version 4.21.0, commit v4.21.0, Release)
+$ lake --version
+Lake version 5.0.0-v4.21.0 (Lean version 4.21.0)
+```
 
 ## Introduction
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Flake providing a devShell with lean4";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "lean4-shell";
+          buildInputs = with pkgs; [
+            lean4
+            glfw
+          ];
+        };
+      }
+    )
+  ;
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,5 +1,9 @@
 import Lake
-open Lake DSL
+open System Lake DSL
+
+-- TIP: To learn about writing a `lakefile.lean` (or `lakefile.toml`), see
+-- https://github.com/leanprover/lean4/blob/master/src/lake/README.md and the
+-- directory `examples/` in there.
 
 package «GlfwTest» where
   -- add package configuration options here
@@ -13,9 +17,19 @@ target native.o (pkg : NPackage _package.name) : FilePath := do
   let native_src := "native.c"
   let native_c := pkg.dir / native_src
   let native_o := pkg.buildDir / "native.o"
-  buildFileAfterDep native_o (<- inputFile native_c) fun native_src => do
+
+  -- TIP: About 'buildFileAfterDep', see
+  -- https://github.com/leanprover/lean4/blob/dfdd682c017a96896d8cfa683f510dd2e0491752/src/lake/Lake/Build/Common.lean#L538.
+
+  -- TIP: About 'inputFile', see
+  -- https://github.com/leanprover/lean4/blob/dfdd682c017a96896d8cfa683f510dd2e0491752/src/lake/Lake/Build/Common.lean#L573.
+
+  -- TIP: About 'compileO', see
+  -- https://github.com/leanprover/lean4/blob/dfdd682c017a96896d8cfa683f510dd2e0491752/src/lake/Lake/Build/Actions.lean#L79
+
+  buildFileAfterDep native_o (<- inputFile native_c True) fun native_src => do
     let lean_dir := (<- getLeanIncludeDir).toString
-    compileO "ausr" native_o native_src #["-I", lean_dir, "-fPIC"]
+    compileO native_o native_src #["-I", lean_dir, "-fPIC"]
 
 extern_lib native (pkg : NPackage _package.name) := do
   let name := nameToStaticLib "native"


### PR DESCRIPTION
Should fix https://github.com/DSLstandard/Lean4-FFI-Programming-Tutorial-GLFW/issues/1.

The problem mainly stemmed from the fact that the type signatures of some Lake util functions used in `lakefile.lean` have  changed:
    - https://github.com/leanprover/lean4/pull/3835 changed the type signature of 'compileO' (src/lake/Lake/Build/Actions.lean)
    - https://github.com/leanprover/lean4/pull/5924 changed the type signature of 'inputFile'.

PR to fix.